### PR TITLE
use new column name in love plot

### DIFF
--- a/chapters/chapter-02.qmd
+++ b/chapters/chapter-02.qmd
@@ -499,8 +499,8 @@ ggplot(
   aes(
     x = abs(smd),
     y = variable,
-    group = weights,
-    color = weights
+    group = method,
+    color = method
   )
 ) +
   geom_love()


### PR DESCRIPTION
Thanks for the wonderful work, yall.🍄

When rendering Ch. 2, I was seeing the following error:

```
Quitting from lines 487-507 (chapter-02.qmd) 
Error in `ggplot2::geom_line()`:
! Problem while computing aesthetics.
ℹ Error occurred in the 2nd layer.
Caused by error in `compute_aesthetics()`:
! Aesthetics are not valid data columns.
✖ The following aesthetics are invalid:
✖ `group = NULL`
✖ `colour = NULL`
ℹ Did you mistype the name of a data column or forget
  to add `after_stat()`?
```

It looks like this was because those two aesthetics were set to a column name that has since been changed in tidysmd. By default, dependencies resolved to use dev tidysmd—I think this is because it's a second-order dependency via halfmoon, which [references the GitHub version](https://github.com/malcolmbarrett/halfmoon/blob/2e29683fd708611559a4bd55e72c6ff9cb214466/DESCRIPTION#L25). This PR follows the lead of https://github.com/malcolmbarrett/halfmoon/commit/e6152708d725bbf8f071d505560745612ede352a and updates those column names. :)