### PR TITLE
Fix documentation and minor issues in examples

### DIFF
--- a/chapters/02-whole-game.qmd
+++ b/chapters/02-whole-game.qmd
@@ -315,11 +315,11 @@ mosquito_dag |>
   dag_paths() |>
   mutate(
     effects = case_when(
-      set == "1" & path == "open path" ~ "true effect",
-      path == "open path" ~ "confounding effect",
-      TRUE ~ NA_character_
+      path_type == "direct" ~ "causal path",
+      path == "open path" ~ "open noncausal path",
+      TRUE ~ "closed path"
     ),
-    effects = factor(effects, c("true effect", "confounding effect"))
+    effects = factor(effects, c("causal path", "open noncausal path"))
   ) |>
   ggplot(aes(
     x = x,
@@ -371,13 +371,13 @@ mosquito_dag |>
     name = NULL,
     na.value = "grey90",
     order = c(3, 6),
-    breaks = c("true effect", "confounding effect")
+    breaks = c("causal path", "open noncausal path")
   ) +
   scale_edge_color_okabe_ito(
     name = NULL,
     na.value = "grey90",
     order = c(3, 6),
-    breaks = c("true effect", "confounding effect")
+    breaks = c("causal path", "open noncausal path")
   ) +
   guides(alpha = "none", edge_alpha = "none")
 ```

--- a/chapters/02-whole-game.qmd
+++ b/chapters/02-whole-game.qmd
@@ -451,7 +451,7 @@ For instance, the 16th household used a bed net and had a predicted probability 
 That's a pretty low probability considering they did, in fact, use a net, so their weight is higher at `r round(net_data_wts$wts[[16]], digits = 2)`.
 In other words, this household will be up-weighted compared to the naive linear model we fit above.
 The first household did *not* use a bed net; they're predicted probability of net use was `r round(net_data_wts$.fitted[[1]], digits = 2)` (or put differently, a predicted probability of *not* using a net of `r 1 - round(net_data_wts$.fitted[[1]], digits = 2)`).
-That's more in line with their observed value of `net`, but there's still some predicted probability of using a net, so their weight is `r round(net_data_wts$wts[[2]], digits = 2)`.
+That's more in line with their observed value of `net`, but there's still some predicted probability of using a net, so their weight is `r round(net_data_wts$wts[[1]], digits = 2)`.
 
 ## Diagnose our models
 

--- a/chapters/02-whole-game.qmd
+++ b/chapters/02-whole-game.qmd
@@ -462,7 +462,7 @@ Here's the distribution of the propensity score by group, created by `geom_mirro
 ```{r}
 #| label: fig-mirror-histogram-net-data-unweighted
 #| fig-cap: >
-#|   A mirrored histogram of the propensity scores of those who used nets (top, blue) versus those who did not use nets (bottom, orange). The range of propensity scores is similar between groups, with those who used nets slightly to the left of those who didn't, but the shapes of the distribution are different.
+#|   A mirrored histogram of the propensity scores of those who used nets (top, blue) versus those who did not use nets (bottom, orange). The range of propensity scores is similar between groups, with those who did not use nets slightly to the left of those who did, but the shapes of the distribution are different.
 
 library(halfmoon)
 ggplot(net_data_wts, aes(.fitted)) +

--- a/chapters/03-po-counterfactuals.qmd
+++ b/chapters/03-po-counterfactuals.qmd
@@ -492,7 +492,7 @@ ggplot(plot_data, aes(happiness, y_id, color = observed, shape = observed)) +
     inherit.aes = FALSE,
     color = "grey40",
     size = 3.75,
-    label.size = NA
+    linewidth = NA
   ) +
   geom_curve(
     data = exchangeability_annotation,
@@ -510,7 +510,7 @@ ggplot(plot_data, aes(happiness, y_id, color = observed, shape = observed)) +
     nudge_x = 0.5,
     color = "grey40",
     size = 4,
-    label.size = NA
+    linewidth = NA
   ) +
   facet_wrap(~potential_outcome) +
   scale_y_continuous(
@@ -982,7 +982,7 @@ ggplot(
     inherit.aes = FALSE,
     color = "grey40",
     size = 4.5,
-    label.size = NA
+    linewidth = NA
   ) +
   facet_wrap(~potential_outcome) +
   scale_y_continuous(
@@ -1065,13 +1065,13 @@ data_observed_poorly_defined <- data |>
       rbinom(n(), 1, 0.25) == 1 ~ "chocolate",
       .default = "vanilla"
     ),
-    observed_outcome = case_match(
+    observed_outcome = recode_values(
       exposure_unobserved,
       "chocolate (spoiled)" ~ y_spoiled_chocolate,
       "chocolate" ~ y_chocolate,
       "vanilla" ~ y_vanilla
     ),
-    exposure = case_match(
+    exposure = recode_values(
       exposure_unobserved,
       c("chocolate (spoiled)", "chocolate") ~ "chocolate",
       "vanilla" ~ "vanilla"
@@ -1079,7 +1079,7 @@ data_observed_poorly_defined <- data |>
   )
 ```
 
-We know the *true* average causal effect of (unspoiled) chocolate in the sample is `r mean(data |> pull(causal_effect))`; however, our estimated causal effect is `r data_observed |> group_by(exposure) |> summarise(avg_outcome = mean(observed_outcome)) |> mutate(exposure = c(1, 0)) |> pivot_wider(names_from = exposure, values_from = avg_outcome, names_prefix = "x_") |> summarise(estimate = x_1 - x_0) |> pull() |> round(1)`.
+We know the *true* average causal effect of (unspoiled) chocolate in the sample is `r mean(data |> pull(causal_effect))`; however, our estimated causal effect is `r data_observed_poorly_defined |> group_by(exposure) |> summarise(avg_outcome = mean(observed_outcome), .groups = "drop") |> summarise(estimate = avg_outcome[exposure == "chocolate"] - avg_outcome[exposure == "vanilla"]) |> pull(estimate) |> round(1)`.
 
 ```{r}
 data_observed_poorly_defined |>
@@ -1089,7 +1089,7 @@ data_observed_poorly_defined |>
 
 The potential outcome we think we are estimating is not the one we are observing.
 We're treating fresh chocolate ice cream and spoiled chocolate ice cream as the same exposure, but they have different effects on the potential outcomes.
-Because the exposure is random, we actually do a pretty good job of estimating the effect of `y(chocolate, spoiled = FALSE) | y(chocolate, spoiled = TRUE)`, but that's not what we're interested in.
+Because the exposure is random, we actually do a pretty good job of estimating the effect of `y(chocolate, spoiled = FALSE) or y(chocolate, spoiled = TRUE)`, but that's not what we're interested in.
 We just want `y(chocolate, spoiled = FALSE)`.
 
 ```{r}
@@ -1242,7 +1242,7 @@ ggplot(plot_data, aes(x = happiness, y = y_id)) +
     inherit.aes = FALSE,
     color = "grey40",
     size = 4,
-    label.size = NA
+    linewidth = NA
   ) +
   geom_curve(
     data = flawed_avg_annotation,
@@ -1259,7 +1259,7 @@ ggplot(plot_data, aes(x = happiness, y = y_id)) +
     inherit.aes = FALSE,
     color = "grey40",
     size = 4,
-    label.size = NA
+    linewidth = NA
   ) +
   geom_curve(
     data = unspoiled_arrows,
@@ -1276,7 +1276,7 @@ ggplot(plot_data, aes(x = happiness, y = y_id)) +
     inherit.aes = FALSE,
     color = "grey40",
     size = 4,
-    label.size = NA
+    linewidth = NA
   ) +
   facet_wrap(~potential_outcome) +
   scale_y_continuous(
@@ -1591,7 +1591,7 @@ ggplot(plot_data, aes(x = happiness, y = y_id)) +
     inherit.aes = FALSE,
     color = "grey40",
     size = 3,
-    label.size = NA
+    linewidth = NA
   ) +
   geom_curve(
     data = unobserved_arrows,
@@ -1608,7 +1608,7 @@ ggplot(plot_data, aes(x = happiness, y = y_id)) +
     inherit.aes = FALSE,
     color = "grey40",
     size = 3,
-    label.size = NA
+    linewidth = NA
   ) +
   geom_curve(
     data = chocolate_unobserved_arrow,
@@ -1625,7 +1625,7 @@ ggplot(plot_data, aes(x = happiness, y = y_id)) +
     inherit.aes = FALSE,
     color = "grey40",
     size = 3,
-    label.size = NA
+    linewidth = NA
   ) +
   facet_wrap(~potential_outcome) +
   scale_y_continuous(


### PR DESCRIPTION
This PR fixes several minor documentation and example issues:
  
- Avoid identifying the causal path with the hard-coded set == "1" condition
- Fix index for weight calculation in the net example
- Fix caption for mirrored histogram in documentation